### PR TITLE
fix params in AuthServer

### DIFF
--- a/src/common/AuthServer.ts
+++ b/src/common/AuthServer.ts
@@ -75,7 +75,7 @@ export class AuthServer extends EventEmitter {
             response.end('NO_URL');
             return;
         }
-        const urlParams = url.substring(2);
+        const urlParams = url.substring(url.indexOf("?"));
         const searchParams = new URLSearchParams(urlParams);
         const queryString: TStringValueObject = Object.fromEntries(searchParams);
         const currentState = this.options.state;


### PR DESCRIPTION
В данном ПР решается проблема с авторизацией через прокси сервер. Очень часто на прод стейджинге падаем с ошибкой NO_CODE т.к. не правильно деструктуризируются параметры из строки